### PR TITLE
make: replicate ci workflow into a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+CURRENT_GIT_BRANCH=$(shell git branch --show-current)
+DEFAULT_GIT_REMOTE=origin
+
+default: push
+	
+install: package.json pnpm-lock.yaml
+	pnpm install --frozen-lockfile
+
+check: install
+	pnpm run check
+
+lint: check
+	pnpm run lint || pnpm run format
+
+build: lint
+	pnpm run build
+
+clean:
+	find build -type f -exec rm {} \+;
+
+build_clean: clean build
+
+push: lint
+	git push ${DEFAULT_GIT_REMOTE} ${CURRENT_GIT_BRANCH}


### PR DESCRIPTION
This is to help local development.

As of now, default behaviour is to git push to origin -- as default remote -- from current branch.

According to documentation, you can use a makefile with Github Actions. That would be a good follow up PR.